### PR TITLE
feat: add scheduler region choice different from workflow's one

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Functional examples are included in the
 | workflow\_labels | A set of key/value label pairs to assign to the workflow | `map(string)` | `{}` | no |
 | workflow\_name | The name of the cloud workflow to create | `string` | n/a | yes |
 | workflow\_source | Workflow YAML code to be executed. The size limit is 32KB. | `string` | n/a | yes |
-| workflow\_trigger | Trigger for the Workflow . Cloud Scheduler OR Event Arc | <pre>object({<br>    cloud_scheduler = optional(object({<br>      name                  = string<br>      cron                  = string<br>      time_zone             = string<br>      deadline              = string<br>      argument              = optional(string)<br>      service_account_email = string<br>    }))<br>    event_arc = optional(object({<br>      name                  = string<br>      service_account_email = string<br>      matching_criteria = set(object({<br>        attribute = string<br>        operator  = optional(string)<br>        value     = string<br>      }))<br>      pubsub_topic_id = optional(string)<br>    }))<br>  })</pre> | n/a | yes |
+| workflow\_trigger | Trigger for the Workflow . Cloud Scheduler OR Event Arc | <pre>object({<br>    cloud_scheduler = optional(object({<br>      name                  = string<br>      cron                  = string<br>      time_zone             = string<br>      deadline              = string<br>      argument              = optional(string)<br>      service_account_email = string<br>      region                = optional(string)<br>    }))<br>    event_arc = optional(object({<br>      name                  = string<br>      service_account_email = string<br>      matching_criteria = set(object({<br>        attribute = string<br>        operator  = optional(string)<br>        value     = string<br>      }))<br>      pubsub_topic_id = optional(string)<br>    }))<br>  })</pre> | n/a | yes |
 
 ## Outputs
 
@@ -112,6 +112,7 @@ Functional examples are included in the
 |------|-------------|
 | event\_arc\_id | Google Event Arc id |
 | scheduler\_job\_id | Google Cloud scheduler job id |
+| scheduler\_region | Google Cloud scheduler region |
 | workflow\_id | Workflow identifier for the resource with format projects/{{project}}/locations/{{region}}/workflows/{{name}} |
 | workflow\_region | The region of the workflow. |
 | workflow\_revision\_id | The revision of the workflow. A new one is generated if the service account or source contents is changed. |

--- a/examples/schedule_workflow_with_scheduler_region/README.md
+++ b/examples/schedule_workflow_with_scheduler_region/README.md
@@ -1,0 +1,27 @@
+# Simple Example
+
+This example illustrates how to use the `cloud-workflow` module.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| scheduler\_job\_id | Google Cloud scheduler job id |
+| workflow\_id | The id  of the workflow. |
+| workflow\_region | The id  of the workflow. |
+| workflow\_revision\_id | The revision\_id  of the workflow. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/schedule_workflow_with_scheduler_region/main.tf
+++ b/examples/schedule_workflow_with_scheduler_region/main.tf
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+data "google_compute_default_service_account" "default" {
+  project = var.project_id
+}
+
+module "service_account" {
+  source        = "terraform-google-modules/service-accounts/google"
+  version       = "~> 4.1.1"
+  project_id    = var.project_id
+  prefix        = "sa-workflow-with-args"
+  names         = ["simple"]
+  project_roles = ["${var.project_id}=>roles/workflows.invoker"]
+}
+
+module "cloud_workflow" {
+  source  = "GoogleCloudPlatform/cloud-workflows/google"
+  version = "~> 0.1"
+
+  project_id            = var.project_id
+  workflow_name         = "wf-sample-with-args"
+  region                = "us-central1"
+  service_account_email = module.service_account.email
+  workflow_trigger = {
+    cloud_scheduler = {
+      name                  = "workflow-job-with-args"
+      cron                  = "*/3 * * * *"
+      time_zone             = "America/New_York"
+      deadline              = "320s"
+      service_account_email = data.google_compute_default_service_account.default.email
+      region                = "us-west1"
+    }
+  }
+  workflow_source = <<-EOF
+  main:
+      params: [input]
+      steps:
+      - checkSearchTermInInput:
+          assign:
+          - searchTerm: $${input.searchTerm}
+      - readWikipedia:
+          call: http.get
+          args:
+              url: https://en.wikipedia.org/w/api.php
+              query:
+                  action: opensearch
+                  search: $${searchTerm}
+          result: wikiResult
+      - returnOutput:
+              return: $${wikiResult.body[1]}
+EOF
+
+}

--- a/examples/schedule_workflow_with_scheduler_region/outputs.tf
+++ b/examples/schedule_workflow_with_scheduler_region/outputs.tf
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "workflow_id" {
+  description = "The id  of the workflow."
+  value       = module.cloud_workflow.workflow_id
+}
+
+
+output "workflow_region" {
+  description = "The id  of the workflow."
+  value       = module.cloud_workflow.workflow_region
+}
+
+output "workflow_revision_id" {
+  description = "The revision_id  of the workflow."
+  value       = module.cloud_workflow.workflow_revision_id
+}
+
+output "scheduler_job_id" {
+  description = "Google Cloud scheduler job id"
+  value       = module.cloud_workflow.scheduler_job_id
+}

--- a/examples/schedule_workflow_with_scheduler_region/variables.tf
+++ b/examples/schedule_workflow_with_scheduler_region/variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}

--- a/examples/schedule_workflow_with_scheduler_region/versions.tf
+++ b/examples/schedule_workflow_with_scheduler_region/versions.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "google_cloud_scheduler_job" "workflow" {
   schedule         = var.workflow_trigger.cloud_scheduler.cron
   time_zone        = var.workflow_trigger.cloud_scheduler.time_zone
   attempt_deadline = var.workflow_trigger.cloud_scheduler.deadline
-  region           = var.region
+  region           = try(var.workflow_trigger.cloud_scheduler.region, var.region)
 
   http_target {
     http_method = "POST"

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -84,6 +84,7 @@ spec:
             time_zone             = string
             deadline              = string
             argument              = optional(string)
+            region                = optional(string)
             service_account_email = string
           }))
           event_arc = optional(object({
@@ -103,6 +104,8 @@ spec:
     description: Google Event Arc id
   - name: scheduler_job_id
     description: Google Cloud scheduler job id
+  - name: scheduler_rgion
+    description: Google Cloud scheduler region
   - name: workflow_id
     description: Workflow identifier for the resource with format projects/{{project}}/locations/{{region}}/workflows/{{name}}
   - name: workflow_region

--- a/test/fixtures/schedule_workflow_with_scheduler_region/README.md
+++ b/test/fixtures/schedule_workflow_with_scheduler_region/README.md
@@ -1,0 +1,29 @@
+# Simple Example
+
+This example illustrates how to use the `cloud-workflow` module.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project\_id | The ID of the project in which to provision resources. | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| project\_id | Google Cloud project in which the service was created |
+| scheduler\_job\_id | Google Cloud scheduler job id |
+| scheduler\_region | Google Cloud scheduler region |
+| workflow\_id | The id  of the workflow. |
+| workflow\_region | The region of the workflow. |
+| workflow\_revision\_id | The revision id of the workflow. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/test/fixtures/schedule_workflow_with_scheduler_region/main.tf
+++ b/test/fixtures/schedule_workflow_with_scheduler_region/main.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "cloud_workflow" {
+  source     = "../../../examples/schedule_workflow_with_scheduler_region"
+  project_id = var.project_id
+}

--- a/test/fixtures/schedule_workflow_with_scheduler_region/outputs.tf
+++ b/test/fixtures/schedule_workflow_with_scheduler_region/outputs.tf
@@ -15,31 +15,31 @@
  */
 
 output "workflow_id" {
-  value       = google_workflows_workflow.workflow.id
-  description = "Workflow identifier for the resource with format projects/{{project}}/locations/{{region}}/workflows/{{name}}"
+  description = "The id  of the workflow."
+  value       = module.cloud_workflow.workflow_id
 }
 
 output "workflow_revision_id" {
-  value       = google_workflows_workflow.workflow.revision_id
-  description = "The revision of the workflow. A new one is generated if the service account or source contents is changed."
+  description = "The revision id of the workflow."
+  value       = module.cloud_workflow.workflow_revision_id
 }
 
 output "workflow_region" {
-  value       = google_workflows_workflow.workflow.region
   description = "The region of the workflow."
+  value       = module.cloud_workflow.workflow_region
+}
+
+output "project_id" {
+  description = "Google Cloud project in which the service was created"
+  value       = var.project_id
 }
 
 output "scheduler_job_id" {
   description = "Google Cloud scheduler job id"
-  value       = local.enable_scheduler == 1 ? google_cloud_scheduler_job.workflow[0].id : null
+  value       = module.cloud_workflow.scheduler_job_id
 }
 
 output "scheduler_region" {
   description = "Google Cloud scheduler region"
-  value       = local.enable_scheduler == 1 ? google_cloud_scheduler_job.workflow[0].region : null
-}
-
-output "event_arc_id" {
-  description = "Google Event Arc id"
-  value       = local.enable_eventarc == 1 ? google_eventarc_trigger.workflow[0].id : null
+  value       = module.cloud_workflow.scheduler_region
 }

--- a/test/fixtures/schedule_workflow_with_scheduler_region/variables.tf
+++ b/test/fixtures/schedule_workflow_with_scheduler_region/variables.tf
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The ID of the project in which to provision resources."
+  type        = string
+}

--- a/test/fixtures/schedule_workflow_with_scheduler_region/versions.tf
+++ b/test/fixtures/schedule_workflow_with_scheduler_region/versions.tf
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 0.13"
+}

--- a/test/integration/schedule_workflow_with_scheduler_region/schedule_workflow_with_scheduler_region_test.go
+++ b/test/integration/schedule_workflow_with_scheduler_region/schedule_workflow_with_scheduler_region_test.go
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package schedule_workflow
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScheduleWorkflowWithArgs(t *testing.T) {
+	bpt := tft.NewTFBlueprintTest(t)
+
+	bpt.DefineVerify(func(assert *assert.Assertions) {
+		waitSeconds := 5
+		bpt.DefaultVerify(assert)
+
+		projectId := bpt.GetStringOutput("project_id")
+		workflowId := bpt.GetStringOutput("workflow_id")
+		workflowRegion := bpt.GetStringOutput("workflow_region")
+		schedulerRegion := bpt.GetStringOutput("scheduler_region")
+		workflowRevisionId := bpt.GetStringOutput("workflow_revision_id")
+		schedulerJobId := bpt.GetStringOutput("scheduler_job_id")
+		gcOpsWorkflow := gcloud.WithCommonArgs([]string{"--project", projectId, "--location", workflowRegion, "--format", "json"})
+		gcOpsScheduler := gcloud.WithCommonArgs([]string{"--project", projectId, "--location", schedulerRegion, "--format", "json"})
+
+		workflowInfo := gcloud.Run(t, "workflows describe "+workflowId, gcOpsWorkflow)
+		assert.Equal(workflowRevisionId, workflowInfo.Get("revisionId").String(), "should have the right Workflow RevisionId")
+
+		schedulerInfo := gcloud.Run(t, "scheduler jobs describe "+schedulerJobId, gcOpsScheduler)
+		assert.NotEmpty(schedulerInfo, "scheduler info should not be empty if right region is used for filtering")
+		assert.Contains(schedulerInfo.Get("httpTarget").Get("uri").String(), workflowId, "should have the right Workflow ID")
+
+		fmt.Println("Sleeping for ", waitSeconds, " seconds")
+		time.Sleep(5 * time.Second)
+
+		schedulerTrigger := gcloud.Run(t, "scheduler jobs run "+schedulerJobId, gcOpsScheduler)
+		assert.Equal("ENABLED", schedulerTrigger.Get("state").String(), "Scheduler Job should be in ENABLED status")
+
+		fmt.Println("Sleeping for ", waitSeconds, " seconds")
+		time.Sleep(5 * time.Second)
+
+		workflowExecution := gcloud.Run(t, "workflows  executions list "+workflowId, gcOpsWorkflow).Array()[0]
+		assert.Equal("SUCCEEDED", workflowExecution.Get("state").String(), "Workflow Job should be in SUCCEEDED status")
+
+		workflowExecutionId := workflowExecution.Get("name").String()
+		workflowExecutionInfo := gcloud.Run(t, "workflows  executions describe --workflow="+workflowId+" "+workflowExecutionId, gcOps)
+		assert.Contains(workflowExecutionInfo.Get("result").String(), "Monday", "Workflow Job result should contain object name")
+
+	})
+
+	bpt.Test()
+}

--- a/variables.tf
+++ b/variables.tf
@@ -55,6 +55,7 @@ variable "workflow_trigger" {
       deadline              = string
       argument              = optional(string)
       service_account_email = string
+      region                = optional(string)
     }))
     event_arc = optional(object({
       name                  = string


### PR DESCRIPTION
This PR allow to specify a region for the cloud scheduler Job different from the Workflow's one.

For example, you might need to deploy the job in a different region than the workflow since the Cloud Scheduler service is not available here (ex: europe-west9)

Add tests and example associated with this situation and so, needs to add an output to filter the scheduler job in tests with the defined region