### PR TITLE
feat!: support google provider 6.x.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,14 @@ Functional examples are included in the
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| call\_log\_level | Describe the level of platform logging to apply to calls and call responses during executions of this workflow. Possible values are: CALL\_LOG\_LEVEL\_UNSPECIFIED, LOG\_ALL\_CALLS, LOG\_ERRORS\_ONLY, LOG\_NONE. | `string` | `null` | no |
+| deletion\_protection | Whether Terraform will be prevented from destroying the workflow. Defaults to true. | `bool` | `null` | no |
+| execution\_history\_level | Describes the level of execution history to be stored for this workflow. Possible values are: EXECUTION\_HISTORY\_LEVEL\_UNSPECIFIED, EXECUTION\_HISTORY\_BASIC, EXECUTION\_HISTORY\_DETAILED. | `string` | `null` | no |
 | project\_id | The project ID to deploy to | `string` | n/a | yes |
 | region | The name of the region where workflow will be created | `string` | n/a | yes |
 | service\_account\_create | Auto-create service account. | `bool` | `false` | no |
 | service\_account\_email | Service account email. Unused if service account is auto-created. | `string` | `null` | no |
+| user\_env\_vars | User-defined environment variables associated with this workflow revision. This map has a maximum length of 20. Each string can take up to 4KiB. Keys cannot be empty strings and cannot start with "GOOGLE" or "WORKFLOWS". | `map(string)` | `{}` | no |
 | workflow\_description | Description for the cloud workflow | `string` | `"Sample workflow Description"` | no |
 | workflow\_labels | A set of key/value label pairs to assign to the workflow | `map(string)` | `{}` | no |
 | workflow\_name | The name of the cloud workflow to create | `string` | n/a | yes |

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ These sections describe requirements for using this module.
 
 The following dependencies must be available:
 
-- [Terraform][terraform] v0.13
-- [Terraform Provider for GCP][terraform-provider-gcp] plugin v3.0
+- [Terraform][terraform] v1.3
+- [Terraform Provider for GCP][terraform-provider-gcp] plugin v6.26
 
 ### Service Account
 

--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ Functional examples are included in the
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| call\_log\_level | Describe the level of platform logging to apply to calls and call responses during executions of this workflow. Possible values are: CALL\_LOG\_LEVEL\_UNSPECIFIED, LOG\_ALL\_CALLS, LOG\_ERRORS\_ONLY, LOG\_NONE. | `string` | `null` | no |
+| call\_log\_level | Describe the level of platform logging to apply to calls and call responses during executions of this workflow. Possible values are: CALL\_LOG\_LEVEL\_UNSPECIFIED, LOG\_ALL\_CALLS, LOG\_ERRORS\_ONLY, LOG\_NONE. | `string` | `"CALL_LOG_LEVEL_UNSPECIFIED"` | no |
 | deletion\_protection | Whether Terraform will be prevented from destroying the workflow. Defaults to true. | `bool` | `null` | no |
-| execution\_history\_level | Describes the level of execution history to be stored for this workflow. Possible values are: EXECUTION\_HISTORY\_LEVEL\_UNSPECIFIED, EXECUTION\_HISTORY\_BASIC, EXECUTION\_HISTORY\_DETAILED. | `string` | `null` | no |
+| execution\_history\_level | Describes the level of execution history to be stored for this workflow. Possible values are: EXECUTION\_HISTORY\_LEVEL\_UNSPECIFIED, EXECUTION\_HISTORY\_BASIC, EXECUTION\_HISTORY\_DETAILED. | `string` | `"EXECUTION_HISTORY_LEVEL_UNSPECIFIED"` | no |
 | project\_id | The project ID to deploy to | `string` | n/a | yes |
 | region | The name of the region where workflow will be created | `string` | n/a | yes |
 | service\_account\_create | Auto-create service account. | `bool` | `false` | no |

--- a/examples/gcs_event_arc_trigger_workflow/main.tf
+++ b/examples/gcs_event_arc_trigger_workflow/main.tf
@@ -74,7 +74,7 @@ module "service_account" {
 
 module "gcs_buckets" {
   source          = "terraform-google-modules/cloud-storage/google"
-  version         = "~> 3.4.0"
+  version         = "~> 6.1.0"
   location        = "us-central1"
   project_id      = var.project_id
   names           = ["wf-bucket"]

--- a/examples/gcs_event_arc_trigger_workflow/main.tf
+++ b/examples/gcs_event_arc_trigger_workflow/main.tf
@@ -64,7 +64,7 @@ resource "random_string" "string" {
 
 module "service_account" {
   source     = "terraform-google-modules/service-accounts/google"
-  version    = "~> 4.1.1"
+  version    = "~> 4.5.3"
   project_id = var.project_id
   prefix     = "gcs-eventarc-workflow"
   names      = ["simple"]
@@ -85,13 +85,13 @@ module "gcs_buckets" {
 }
 
 module "cloud_workflow" {
-  source  = "GoogleCloudPlatform/cloud-workflows/google"
-  version = "~> 0.1"
+  source = "../.."
 
   project_id            = var.project_id
   workflow_name         = "wf-gcs-eventarc"
   region                = "us-central1"
   service_account_email = module.service_account.email
+  deletion_protection   = false
   workflow_trigger = {
     event_arc = {
       name                  = "trigger-gcs-workflow-tf"

--- a/examples/gcs_event_arc_trigger_workflow/main.tf
+++ b/examples/gcs_event_arc_trigger_workflow/main.tf
@@ -85,7 +85,8 @@ module "gcs_buckets" {
 }
 
 module "cloud_workflow" {
-  source = "../.."
+  source  = "GoogleCloudPlatform/cloud-workflows/google"
+  version = "~> 0.1"
 
   project_id            = var.project_id
   workflow_name         = "wf-gcs-eventarc"

--- a/examples/gcs_event_arc_trigger_workflow/versions.tf
+++ b/examples/gcs_event_arc_trigger_workflow/versions.tf
@@ -18,12 +18,12 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
 
     random = {
       version = "~> 3.4.3"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/examples/pubsub_event_arc_trigger_workflow/main.tf
+++ b/examples/pubsub_event_arc_trigger_workflow/main.tf
@@ -24,7 +24,7 @@ resource "google_pubsub_topic" "event_arc" {
 
 module "service_account" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 4.1.1"
+  version       = "~> 4.5.3"
   project_id    = var.project_id
   prefix        = "eventarc-workflow"
   names         = ["simple"]
@@ -32,13 +32,13 @@ module "service_account" {
 }
 
 module "cloud_workflow" {
-  source  = "GoogleCloudPlatform/cloud-workflows/google"
-  version = "~> 0.1"
+  source = "../.."
 
   project_id            = var.project_id
   workflow_name         = "wf-pubsub-eventarc"
   region                = "us-central1"
   service_account_email = module.service_account.email
+  deletion_protection   = false
   workflow_trigger = {
     event_arc = {
       name                  = "trigger-pubsub-workflow-tf"

--- a/examples/pubsub_event_arc_trigger_workflow/main.tf
+++ b/examples/pubsub_event_arc_trigger_workflow/main.tf
@@ -32,7 +32,8 @@ module "service_account" {
 }
 
 module "cloud_workflow" {
-  source = "../.."
+  source  = "GoogleCloudPlatform/cloud-workflows/google"
+  version = "~> 0.1"
 
   project_id            = var.project_id
   workflow_name         = "wf-pubsub-eventarc"

--- a/examples/pubsub_event_arc_trigger_workflow/versions.tf
+++ b/examples/pubsub_event_arc_trigger_workflow/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/examples/schedule_workflow/main.tf
+++ b/examples/schedule_workflow/main.tf
@@ -19,7 +19,7 @@ data "google_compute_default_service_account" "default" {
 
 module "service_account" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 4.1.1"
+  version       = "~> 4.5.3"
   project_id    = var.project_id
   prefix        = "sa-workflow"
   names         = ["simple"]
@@ -27,13 +27,18 @@ module "service_account" {
 }
 
 module "cloud_workflow" {
-  source  = "GoogleCloudPlatform/cloud-workflows/google"
-  version = "~> 0.1"
+  source = "../.."
 
-  project_id            = var.project_id
-  workflow_name         = "wf-sample"
-  region                = "us-central1"
-  service_account_email = module.service_account.email
+  project_id              = var.project_id
+  workflow_name           = "wf-sample"
+  region                  = "us-central1"
+  service_account_email   = module.service_account.email
+  call_log_level          = "CALL_LOG_LEVEL_UNSPECIFIED"
+  execution_history_level = "EXECUTION_HISTORY_BASIC"
+  user_env_vars = {
+    key = "value1"
+  }
+  deletion_protection = false
   workflow_trigger = {
     cloud_scheduler = {
       name                  = "workflow-job"

--- a/examples/schedule_workflow/main.tf
+++ b/examples/schedule_workflow/main.tf
@@ -27,7 +27,8 @@ module "service_account" {
 }
 
 module "cloud_workflow" {
-  source = "../.."
+  source  = "GoogleCloudPlatform/cloud-workflows/google"
+  version = "~> 0.1"
 
   project_id              = var.project_id
   workflow_name           = "wf-sample"

--- a/examples/schedule_workflow/versions.tf
+++ b/examples/schedule_workflow/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/examples/schedule_workflow_autocreate_sa/main.tf
+++ b/examples/schedule_workflow_autocreate_sa/main.tf
@@ -18,7 +18,8 @@ data "google_compute_default_service_account" "default" {
 }
 
 module "cloud_workflow" {
-  source = "../.."
+  source  = "GoogleCloudPlatform/cloud-workflows/google"
+  version = "~> 0.1"
 
   project_id              = var.project_id
   workflow_name           = "wf-sample-with-sa"

--- a/examples/schedule_workflow_autocreate_sa/main.tf
+++ b/examples/schedule_workflow_autocreate_sa/main.tf
@@ -18,13 +18,18 @@ data "google_compute_default_service_account" "default" {
 }
 
 module "cloud_workflow" {
-  source  = "GoogleCloudPlatform/cloud-workflows/google"
-  version = "~> 0.1"
+  source = "../.."
 
-  project_id             = var.project_id
-  workflow_name          = "wf-sample-with-sa"
-  region                 = "us-central1"
-  service_account_create = true
+  project_id              = var.project_id
+  workflow_name           = "wf-sample-with-sa"
+  region                  = "us-central1"
+  service_account_create  = true
+  call_log_level          = "CALL_LOG_LEVEL_UNSPECIFIED"
+  execution_history_level = "EXECUTION_HISTORY_BASIC"
+  user_env_vars = {
+    key = "value1"
+  }
+  deletion_protection = false
   workflow_trigger = {
     cloud_scheduler = {
       name                  = "workflow-job-with-sa"

--- a/examples/schedule_workflow_autocreate_sa/versions.tf
+++ b/examples/schedule_workflow_autocreate_sa/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/examples/schedule_workflow_with_arguments/main.tf
+++ b/examples/schedule_workflow_with_arguments/main.tf
@@ -19,7 +19,7 @@ data "google_compute_default_service_account" "default" {
 
 module "service_account" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 4.1.1"
+  version       = "~> 4.5.3"
   project_id    = var.project_id
   prefix        = "sa-workflow-with-args"
   names         = ["simple"]
@@ -27,13 +27,13 @@ module "service_account" {
 }
 
 module "cloud_workflow" {
-  source  = "GoogleCloudPlatform/cloud-workflows/google"
-  version = "~> 0.1"
+  source = "../.."
 
   project_id            = var.project_id
   workflow_name         = "wf-sample-with-args"
   region                = "us-central1"
   service_account_email = module.service_account.email
+  deletion_protection   = false
   workflow_trigger = {
     cloud_scheduler = {
       name                  = "workflow-job-with-args"

--- a/examples/schedule_workflow_with_arguments/main.tf
+++ b/examples/schedule_workflow_with_arguments/main.tf
@@ -27,7 +27,8 @@ module "service_account" {
 }
 
 module "cloud_workflow" {
-  source = "../.."
+  source  = "GoogleCloudPlatform/cloud-workflows/google"
+  version = "~> 0.1"
 
   project_id            = var.project_id
   workflow_name         = "wf-sample-with-args"

--- a/examples/schedule_workflow_with_arguments/versions.tf
+++ b/examples/schedule_workflow_with_arguments/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/main.tf
+++ b/main.tf
@@ -108,7 +108,7 @@ resource "random_string" "string" {
 module "service_account" {
   count         = var.service_account_create ? 1 : 0
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "~> 4.1.1"
+  version       = "~> 4.5.3"
   project_id    = var.project_id
   prefix        = "wf-${random_string.string[0].result}"
   names         = ["simple"]

--- a/main.tf
+++ b/main.tf
@@ -116,11 +116,15 @@ module "service_account" {
 }
 
 resource "google_workflows_workflow" "workflow" {
-  name            = var.workflow_name
-  region          = var.region
-  description     = var.workflow_description
-  service_account = local.service_account_email
-  project         = var.project_id
-  labels          = var.workflow_labels
-  source_contents = var.workflow_source
+  name                    = var.workflow_name
+  region                  = var.region
+  description             = var.workflow_description
+  service_account         = local.service_account_email
+  project                 = var.project_id
+  labels                  = var.workflow_labels
+  source_contents         = var.workflow_source
+  call_log_level          = var.call_log_level
+  execution_history_level = var.execution_history_level
+  user_env_vars           = var.user_env_vars
+  deletion_protection     = var.deletion_protection
 }

--- a/test/fixtures/gcs_event_arc_trigger_workflow/versions.tf
+++ b/test/fixtures/gcs_event_arc_trigger_workflow/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/test/fixtures/pubsub_event_arc_trigger_workflow/versions.tf
+++ b/test/fixtures/pubsub_event_arc_trigger_workflow/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/test/fixtures/schedule_workflow/versions.tf
+++ b/test/fixtures/schedule_workflow/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/test/fixtures/schedule_workflow_autocreate_sa/versions.tf
+++ b/test/fixtures/schedule_workflow_autocreate_sa/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/test/fixtures/schedule_workflow_with_arguments/versions.tf
+++ b/test/fixtures/schedule_workflow_with_arguments/versions.tf
@@ -18,8 +18,8 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = "~> 6.26"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -94,10 +94,10 @@ variable "service_account_create" {
 variable "call_log_level" {
   description = "Describe the level of platform logging to apply to calls and call responses during executions of this workflow. Possible values are: CALL_LOG_LEVEL_UNSPECIFIED, LOG_ALL_CALLS, LOG_ERRORS_ONLY, LOG_NONE."
   type        = string
-  default     = null
+  default     = "CALL_LOG_LEVEL_UNSPECIFIED"
 
   validation {
-    condition     = var.call_log_level == null || contains(["CALL_LOG_LEVEL_UNSPECIFIED", "LOG_ALL_CALLS", "LOG_ERRORS_ONLY", "LOG_NONE"], var.call_log_level)
+    condition     = contains(["CALL_LOG_LEVEL_UNSPECIFIED", "LOG_ALL_CALLS", "LOG_ERRORS_ONLY", "LOG_NONE"], var.call_log_level)
     error_message = "Invalid value for call_log_level. Possible values are: CALL_LOG_LEVEL_UNSPECIFIED, LOG_ALL_CALLS, LOG_ERRORS_ONLY, LOG_NONE."
   }
 }
@@ -105,10 +105,10 @@ variable "call_log_level" {
 variable "execution_history_level" {
   description = "Describes the level of execution history to be stored for this workflow. Possible values are: EXECUTION_HISTORY_LEVEL_UNSPECIFIED, EXECUTION_HISTORY_BASIC, EXECUTION_HISTORY_DETAILED."
   type        = string
-  default     = null
+  default     = "EXECUTION_HISTORY_LEVEL_UNSPECIFIED"
 
   validation {
-    condition     = var.execution_history_level == null || contains(["EXECUTION_HISTORY_LEVEL_UNSPECIFIED", "EXECUTION_HISTORY_BASIC", "EXECUTION_HISTORY_DETAILED"], var.execution_history_level)
+    condition     = contains(["EXECUTION_HISTORY_LEVEL_UNSPECIFIED", "EXECUTION_HISTORY_BASIC", "EXECUTION_HISTORY_DETAILED"], var.execution_history_level)
     error_message = "Invalid value for call_log_level. Possible values are: EXECUTION_HISTORY_LEVEL_UNSPECIFIED, EXECUTION_HISTORY_BASIC, EXECUTION_HISTORY_DETAILED."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,37 @@ variable "service_account_create" {
   type        = bool
   default     = false
 }
+
+variable "call_log_level" {
+  description = "Describe the level of platform logging to apply to calls and call responses during executions of this workflow. Possible values are: CALL_LOG_LEVEL_UNSPECIFIED, LOG_ALL_CALLS, LOG_ERRORS_ONLY, LOG_NONE."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.call_log_level == null || contains(["CALL_LOG_LEVEL_UNSPECIFIED", "LOG_ALL_CALLS", "LOG_ERRORS_ONLY", "LOG_NONE"], var.call_log_level)
+    error_message = "Invalid value for call_log_level. Possible values are: CALL_LOG_LEVEL_UNSPECIFIED, LOG_ALL_CALLS, LOG_ERRORS_ONLY, LOG_NONE."
+  }
+}
+
+variable "execution_history_level" {
+  description = "Describes the level of execution history to be stored for this workflow. Possible values are: EXECUTION_HISTORY_LEVEL_UNSPECIFIED, EXECUTION_HISTORY_BASIC, EXECUTION_HISTORY_DETAILED."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.execution_history_level == null || contains(["EXECUTION_HISTORY_LEVEL_UNSPECIFIED", "EXECUTION_HISTORY_BASIC", "EXECUTION_HISTORY_DETAILED"], var.execution_history_level)
+    error_message = "Invalid value for call_log_level. Possible values are: EXECUTION_HISTORY_LEVEL_UNSPECIFIED, EXECUTION_HISTORY_BASIC, EXECUTION_HISTORY_DETAILED."
+  }
+}
+
+variable "user_env_vars" {
+  description = "User-defined environment variables associated with this workflow revision. This map has a maximum length of 20. Each string can take up to 4KiB. Keys cannot be empty strings and cannot start with \"GOOGLE\" or \"WORKFLOWS\"."
+  type        = map(string)
+  default     = {}
+}
+
+variable "deletion_protection" {
+  description = "Whether Terraform will be prevented from destroying the workflow. Defaults to true."
+  type        = bool
+  default     = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 7.0"
+      version = ">= 6.26, < 7.0"
     }
 
     random = {

--- a/versions.tf
+++ b/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53, < 5.0"
+      version = ">= 3.53, < 7.0"
     }
 
     random = {


### PR DESCRIPTION
This PR to add support for google provider version 6.x.x. Currently, this module is not compatible with provider version 6.x.x due to dependencies.

```
│ Error: Failed to query available provider packages
│
│ Could not retrieve the list of available versions for provider hashicorp/google: no available releases match the given constraints >= 3.53.0, < 5.0.0, >= 5.22.0, ~> 6.26, < 7.0.0
```

I also add some variable to be used for latest parameters available in google provider version 6.26:
- call_log_level
- execution_history_level
- user_env_vars
- deletion_protection